### PR TITLE
divides latest price by granularity

### DIFF
--- a/src/components/FeedTable/index.js
+++ b/src/components/FeedTable/index.js
@@ -66,9 +66,13 @@ export default () => {
         });
         Promise.all(apiPromises).then(function(values) {
           const totalTips = [..._.map(values, "data")];
-          totalTips.map(
-            (tipObj, index) => (tempTableData[index].totalTip = tipObj.totalTip)
-          );
+          totalTips.map((tipObj, index) => {
+            tempTableData[index].totalTip = tipObj.totalTip;
+            tempTableData[index].granularity = tipObj.granularity;
+
+            return tempTableData[index];
+          });
+
           setTableData(tempTableData);
           setTotalTipsLoading(false);
         });
@@ -76,6 +80,10 @@ export default () => {
           const prices = [..._.map(values, "data")];
           prices.map((priceObj, index) => {
             tempTableData[index].price = priceObj.value;
+            tempTableData[index].granPrice =
+              +priceObj.value / +tempTableData[index].granularity;
+
+            return tempTableData[index];
           });
           setTableData(tempTableData);
           setPriceLoading(false);
@@ -140,7 +148,8 @@ export default () => {
     <Fragment>
       <Table dataSource={tableData} bordered pagination={false} rowKey="type">
         <Column title="Type" dataIndex="type" key="type" />
-        <Column title="Last Update" dataIndex="price" key="price" />
+        <Column title="Last Value" dataIndex="price" key="price" />
+        <Column title="Price" dataIndex="granPrice" key="granPrice" />
         <Column title="Current Tip" dataIndex="totalTip" key="totalTip" />
         <Column
           title=""


### PR DESCRIPTION
Just working with how this was implemented - granularity seems to get returned from the api http://api.tellorscan.com/requestinfo/id. Diving the latest price by that value.

Let me know if this is what's expected.
![Screenshot from 2020-06-16 09-29-51](https://user-images.githubusercontent.com/6923345/84795256-7a5b4f80-afb4-11ea-889d-07de9a28b6d3.png)

https://github.com/tellor-io/tellorPriceView/issues/7